### PR TITLE
add http.Flusher interface implementation to responseRecorder

### DIFF
--- a/modules/caddyhttp/responsewriter.go
+++ b/modules/caddyhttp/responsewriter.go
@@ -246,6 +246,13 @@ func (rr *responseRecorder) FlushError() error {
 	return nil
 }
 
+func (rr *responseRecorder) Flush() {
+	if rr.stream {
+		//nolint:bodyclose
+		http.NewResponseController(rr.ResponseWriterWrapper).Flush()
+	}
+}
+
 // Private interface so it can only be used in this package
 // #TODO: maybe export it later
 func (rr *responseRecorder) setReadSize(size *int) {


### PR DESCRIPTION
Add `http.Flusher` interface implementation to responseRecorder.

Some implementation of SSE streaming ONLY checks the `Flusher` interface, then do Flush.  Such as goa. 